### PR TITLE
EBS Payment Bug Fixes

### DIFF
--- a/ebs-payment-gateway-woocommerce.php
+++ b/ebs-payment-gateway-woocommerce.php
@@ -219,7 +219,7 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
                             $order->add_order_note(__($notes, 'woocommerce'));
 
                         }
-
+						do_action( 'ebs_payment_gateway_after_payment_processed', $response, $order_id, $order );
                     }catch(Exception $e){
                             // $errorOccurred = true;
                         $msg = "Error";

--- a/ebs-payment-gateway-woocommerce.php
+++ b/ebs-payment-gateway-woocommerce.php
@@ -248,6 +248,7 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
             $redirect_url = ($this -> redirect_page_id=="" || $this -> redirect_page_id==0)?get_site_url() . "/":get_permalink($this -> redirect_page_id);
           //For wooCoomerce 2.0
             $redirect_url = add_query_arg( 'wc-api', get_class( $this ), $redirect_url );
+			$redirect_url = add_query_arg( 'DR', '{DR}', $redirect_url  );
 
             $order_id = $order->id;
             $description = $order->customer_note;

--- a/ebs-payment-gateway-woocommerce.php
+++ b/ebs-payment-gateway-woocommerce.php
@@ -263,15 +263,6 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
             $hash = $secret_key."|".$account_id."|".$amount."|".$order_id."|".$redirect_url."|".$mode;
             $secure_hash = md5($hash);
 
-			error_log($secret_key);
-			error_log($account_id);
-			error_log($amount);
-			error_log($order_id);
-			error_log($redirect_url);
-			error_log($mode);
-			error_log($hash);
-			error_log($secure_hash);
-
             $ebs_args = array(
                 'account_id' => $account_id,
                 'secret_key' => $secret_key,


### PR DESCRIPTION
The Pay Page for EBS is not getting dispalyed. 
The hook name for woocommerce_reciepet was used wrong.
Used : ccavenue
Rather it should be "ebs" which is the name/id of the payment gateway.

There were a few null checks left which I've added. And $return_url variable was used wrong.
